### PR TITLE
Migrate to Swift 5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,5 +31,5 @@ let package = Package(
             ]
         )
         ],
-    swiftLanguageVersions: [4]
+    swiftLanguageVersions: [5]
 )

--- a/Sources/DBus/Connection.swift
+++ b/Sources/DBus/Connection.swift
@@ -103,7 +103,7 @@ public final class DBusConnection {
     // MARK: - Class Methods
     
     /// This method sets a global flag for whether `dbus_connection_new()` will set `SIGPIPE` behavior to `SIG_IGN`.
-    public static func setChangeSIGPIPE(change: Bool) {
+    static func setChangeSIGPIPE(change: Bool) {
         
         dbus_connection_set_change_sigpipe(dbus_bool_t(change))
     }

--- a/Sources/DBus/Error.swift
+++ b/Sources/DBus/Error.swift
@@ -30,7 +30,7 @@ public struct DBusError: Error, Equatable, Hashable {
 internal extension DBusError {
     
     /// Internal class for working with the C DBus error API
-    internal final class Reference {
+    final class Reference {
         
         // MARK: - Internal Properties
         
@@ -126,7 +126,7 @@ extension DBusError: CustomNSError {
 
 public extension DBusError {
     
-    public struct Name: Equatable, Hashable {
+    struct Name: Equatable, Hashable {
         
         public let rawValue: String
         
@@ -143,7 +143,7 @@ public extension DBusError {
 
 public extension DBusError.Name {
     
-    public init(_ interface: DBusInterface) {
+    init(_ interface: DBusInterface) {
         
         // should be valid
         self.rawValue = interface.rawValue
@@ -163,32 +163,32 @@ public extension DBusError.Name {
     /// A generic error; "something went wrong" - see the error message for more.
     ///
     /// `org.freedesktop.DBus.Error.Failed`
-    public static let failed = DBusError.Name(rawValue: DBUS_ERROR_FAILED)!
+    static let failed = DBusError.Name(rawValue: DBUS_ERROR_FAILED)!
     
     /// No Memory
     ///
     /// `org.freedesktop.DBus.Error.NoMemory`
-    public static let noMemory = DBusError.Name(rawValue: DBUS_ERROR_NO_MEMORY)!
+    static let noMemory = DBusError.Name(rawValue: DBUS_ERROR_NO_MEMORY)!
     
     /// Existing file and the operation you're using does not silently overwrite.
     ///
     /// `org.freedesktop.DBus.Error.FileExists`
-    public static let fileExists = DBusError.Name(rawValue: DBUS_ERROR_FILE_EXISTS)!
+    static let fileExists = DBusError.Name(rawValue: DBUS_ERROR_FILE_EXISTS)!
     
     /// Missing file.
     ///
     /// `org.freedesktop.DBus.Error.FileNotFound`
-    public static let fileNotFound = DBusError.Name(rawValue: DBUS_ERROR_FILE_NOT_FOUND)!
+    static let fileNotFound = DBusError.Name(rawValue: DBUS_ERROR_FILE_NOT_FOUND)!
     
     /// Invalid arguments
     ///
     /// `org.freedesktop.DBus.Error.InvalidArgs`
-    public static let invalidArguments = DBusError.Name(rawValue: DBUS_ERROR_INVALID_ARGS)!
+    static let invalidArguments = DBusError.Name(rawValue: DBUS_ERROR_INVALID_ARGS)!
     
     /// Invalid signature
     ///
     /// `org.freedesktop.DBus.Error.InvalidSignature`
-    public static let invalidSignature = DBusError.Name(rawValue: DBUS_ERROR_INVALID_SIGNATURE)!
+    static let invalidSignature = DBusError.Name(rawValue: DBUS_ERROR_INVALID_SIGNATURE)!
 }
 
 extension DBusError.Name: CustomStringConvertible {

--- a/Sources/DBus/Interface.swift
+++ b/Sources/DBus/Interface.swift
@@ -37,7 +37,7 @@ import CDBus
  */
 public struct DBusInterface {
     
-    @_versioned
+    @usableFromInline
     internal private(set) var elements: [Element]
     
     /// Cached string.
@@ -46,7 +46,7 @@ public struct DBusInterface {
     /// - Note: Any subsequent mutation will set this value to nil, and `rawValue` and `description` getters
     /// will have to rebuild the string for every invocation. Mutating leads to an unoptimized code path,
     /// but for values created from either a string or an array of elements, this value is cached.
-    @_versioned
+    @usableFromInline
     internal private(set) var string: String?
     
     /// Initialize with an array of elements.
@@ -226,7 +226,7 @@ extension DBusInterface: RandomAccessCollection { }
 public extension DBusInterface {
     
     /// An element in the object path
-    public struct Element {
+    struct Element {
         
         /// Don't copy buffer of individual elements, because these elements will always be created
         /// from a bigger string, which we should just internally reference.

--- a/Sources/DBus/Message.swift
+++ b/Sources/DBus/Message.swift
@@ -365,7 +365,7 @@ public extension DBusMessage {
     /**
      Creates a new message that is an exact replica of the message specified, except that its refcount is set to 1, its message serial is reset to 0, and if the original message was "locked" (in the outgoing message queue and thus not modifiable) the new message will not be locked.
     */
-    public func copy() throws -> DBusMessage {
+    func copy() throws -> DBusMessage {
         
         guard let copyPointer = dbus_message_copy(internalPointer)
             else { throw DBusError(name: .noMemory, message: "Could not copy message") }
@@ -391,7 +391,7 @@ extension DBusMessage: Sequence {
 public extension DBusMessage {
     
     /// DBus Message Iterator
-    public struct Iterator: IteratorProtocol {
+    struct Iterator: IteratorProtocol {
         
         public typealias Element = DBusMessageArgument
         
@@ -416,7 +416,7 @@ public extension DBusMessage {
 
 public extension DBusMessage {
     
-    public struct Error {
+    struct Error {
         
         public let replyTo: DBusMessage
         public let name: DBusError.Name
@@ -438,7 +438,7 @@ public extension DBusMessage {
 
 public extension DBusMessage {
     
-    public struct MethodCall {
+    struct MethodCall {
         
         public let destination: DBusBusName?
         public let path: DBusObjectPath
@@ -450,7 +450,7 @@ public extension DBusMessage {
 public extension DBusMessage {
     
     /// A signal is identified by its originating object path, interface, and the name of the signal.
-    public struct Signal {
+    struct Signal {
         
         public let path: String
         public let interface: String

--- a/Sources/DBus/MessageArgument.swift
+++ b/Sources/DBus/MessageArgument.swift
@@ -35,7 +35,7 @@ public enum DBusMessageArgument: Equatable {
 public extension DBusMessageArgument {
     
     /// Argument value type. 
-    public var type: DBusSignature.ValueType {
+    var type: DBusSignature.ValueType {
         
         switch self {
         case .byte: return .byte
@@ -62,7 +62,7 @@ public extension DBusMessageArgument {
 public extension DBusMessageArgument {
     
     /// File Descriptor
-    public struct FileDescriptor: RawRepresentable, Equatable, Hashable {
+    struct FileDescriptor: RawRepresentable, Equatable, Hashable {
         
         public var rawValue: CInt
         
@@ -76,7 +76,7 @@ public extension DBusMessageArgument {
 public extension DBusMessageArgument {
     
     /// Structure
-    public struct Structure: Equatable {
+    struct Structure: Equatable {
         
         /// Structure elements.
         internal let elements: [DBusMessageArgument]
@@ -148,7 +148,7 @@ extension DBusMessageArgument.Structure: RandomAccessCollection {
 
 public extension DBusMessageArgument {
     
-    public struct Array: Equatable {
+    struct Array: Equatable {
         
         /// Array elements.
         internal let elements: [DBusMessageArgument]

--- a/Sources/DBus/ObjectPath.swift
+++ b/Sources/DBus/ObjectPath.swift
@@ -27,7 +27,7 @@ import CDBus
  */
 public struct DBusObjectPath {
     
-    @_versioned
+    @usableFromInline
     internal private(set) var elements: [Element]
     
     /// Cached string.
@@ -36,7 +36,7 @@ public struct DBusObjectPath {
     /// - Note: Any subsequent mutation will set this value to nil, and `rawValue` and `description` getters
     /// will have to rebuild the string for every invocation. So mutating leads to the unoptimized code path,
     /// but for values created from either a string or an array of elements, this value is cached.
-    @_versioned
+    @usableFromInline
     internal private(set) var string: String?
     
     /// Initialize with an array of elements.
@@ -274,7 +274,7 @@ extension DBusObjectPath: RandomAccessCollection { }
 public extension DBusObjectPath {
     
     /// An element in the object path
-    public struct Element {
+    struct Element {
         
         /// Don't copy buffer of individual elements, because these elements will always be created
         /// from a bigger string, which we should just internally reference.

--- a/Sources/DBus/Signature.swift
+++ b/Sources/DBus/Signature.swift
@@ -11,7 +11,7 @@ import CDBus
 public struct DBusSignature {
     
     /// Elements.
-    @_versioned
+    @usableFromInline
     internal private(set) var elements: [Element]
     
     /// Cached string.
@@ -20,7 +20,7 @@ public struct DBusSignature {
     /// - Note: Any subsequent mutation will set this value to nil, and `rawValue` and `description` getters
     /// will have to rebuild the string for every invocation. Mutating leads to an unoptimized code path,
     /// but for values created from either a string or an array of elements, this value is cached.
-    @_versioned
+    @usableFromInline
     internal private(set) var string: String?
     
     public init(_ elements: [Element] = []) {
@@ -359,7 +359,7 @@ extension DBusSignature: RandomAccessCollection { }
 
 public extension DBusSignature {
     
-    public indirect enum ValueType: Equatable {
+    indirect enum ValueType: Equatable {
         
         /// Type code marking an 8-bit unsigned integer.
         case byte
@@ -432,7 +432,7 @@ public extension DBusSignature {
 
 public extension DBusSignature.ValueType {
     
-    public var isContainer: Bool {
+    var isContainer: Bool {
         
         switch self {
         case .struct,
@@ -464,7 +464,7 @@ public extension String {
 public extension DBusSignature {
     
     /// DBus Signature Character
-    public enum Character: String {
+    enum Character: String {
         
         // MARK: - Fixed Length Types
         
@@ -592,7 +592,7 @@ public extension String {
 
 public extension DBusSignature {
     
-    public struct DictionaryType: Equatable {
+    struct DictionaryType: Equatable {
         
         public let key: ValueType
         
@@ -636,9 +636,9 @@ extension DBusSignature.DictionaryType: RawRepresentable {
 
 public extension DBusSignature {
     
-    public struct StructureType {
+    struct StructureType {
         
-        @_versioned
+        @usableFromInline
         internal private(set) var elements: [ValueType]
         
         /// Empty structures are not allowed; there must be at least one type code between the parentheses.
@@ -662,7 +662,7 @@ extension DBusSignature.StructureType: Equatable {
 
 public extension DBusSignature.StructureType {
     
-    public var characters: [DBusSignature.Character] {
+    var characters: [DBusSignature.Character] {
         
         return [.structStart] + elements.reduce([], { $0 + $1.characters }) + [.structEnd]
     }

--- a/Sources/DBus/Timeout.swift
+++ b/Sources/DBus/Timeout.swift
@@ -20,9 +20,9 @@ public struct Timeout: RawRepresentable {
 
 public extension Timeout {
     
-    public static let `default`: Timeout = -1 //Timeout(rawValue: DBUS_TIMEOUT_USE_DEFAULT)
+    static let `default`: Timeout = -1 //Timeout(rawValue: DBUS_TIMEOUT_USE_DEFAULT)
     
-    public static let infinite: Timeout = Timeout(rawValue: .max) //Timeout(rawValue: DBUS_TIMEOUT_INFINITE)
+    static let infinite: Timeout = Timeout(rawValue: .max) //Timeout(rawValue: DBUS_TIMEOUT_INFINITE)
 }
 
 extension Timeout: ExpressibleByIntegerLiteral {


### PR DESCRIPTION
Eliminate Swift 5 compiler warnings.

Please note this PR requires https://github.com/PureSwift/CDBus/pull/1 to be pulled as well.

Cheers!

Best regards,

Jens Schwarzer :)